### PR TITLE
Added githubHost to subscriptions

### DIFF
--- a/db/migrations/20210804152157-update-subscription.js
+++ b/db/migrations/20210804152157-update-subscription.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Subscriptions', 'githubHost', {
+      type: Sequelize.STRING,
+      allowNull: true
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Subscriptions', 'githubHost')
+  }
+}

--- a/lib/frontend/app.js
+++ b/lib/frontend/app.js
@@ -116,7 +116,7 @@ module.exports = (appTokenGenerator) => {
   app.post('/github/configuration', csrfProtection, postGitHubConfiguration);
 
   app.get('/github/installations', csrfProtection, oauth.checkGithubAuth, listGitHubInstallations);
-  app.get('/github/subscriptions/:installationId', csrfProtection, getGitHubSubscriptions);
+  app.get('/github/subscriptions', csrfProtection, getGitHubSubscriptions);
   app.post('/github/subscription', csrfProtection, deleteGitHubSubscription);
 
   app.get('/jira/configuration', csrfProtection, verifyJiraMiddleware, getJiraConfiguration);

--- a/lib/frontend/get-github-configuration.js
+++ b/lib/frontend/get-github-configuration.js
@@ -45,7 +45,7 @@ module.exports = async (req, res, next) => {
         info,
         jiraHost,
         clientKey,
-        APP_URL: process.env.APP_URL,
+        appUrl: process.env.APP_URL,
       });
     } catch (err) {
       // If we get here, there was either a problem decoding the JWT

--- a/lib/frontend/get-github-configuration.js
+++ b/lib/frontend/get-github-configuration.js
@@ -45,6 +45,7 @@ module.exports = async (req, res, next) => {
         info,
         jiraHost,
         clientKey,
+        APP_URL: process.env.APP_URL,
       });
     } catch (err) {
       // If we get here, there was either a problem decoding the JWT

--- a/lib/frontend/get-github-subscriptions.js
+++ b/lib/frontend/get-github-subscriptions.js
@@ -13,7 +13,7 @@ module.exports = async (req, res, next) => {
     // get the installation to see if the user is an admin of it
     const { data: installation } = await client.apps.getInstallation({ installation_id: installationId });
     // get all subscriptions from the database for this installation ID and githubHost
-    const githubHost = new URL(installation.html_url).hostname;
+    const githubHost = (installation && installation.html_url && new URL(installation.html_url).hostname);
     const subscriptions = await Subscription.getAllForInstallation(installationId, githubHost);
     // Only show the page if the logged in user is an admin of this installation
     if (await isAdmin({

--- a/lib/frontend/get-github-subscriptions.js
+++ b/lib/frontend/get-github-subscriptions.js
@@ -13,7 +13,11 @@ module.exports = async (req, res, next) => {
     // get the installation to see if the user is an admin of it
     const { data: installation } = await client.apps.getInstallation({ installation_id: installationId });
     // get all subscriptions from the database for this installation ID and githubHost
-    const githubHost = (installation && installation.html_url && new URL(installation.html_url).hostname);
+    if (!installation || !installation.html_url) {
+      console.log(`html_url in Installation payload is empty. installation=${installationId}`);
+      return next(new Error('html_url in Installation payload is empty'));
+    }
+    const githubHost = new URL(installation.html_url).hostname;
     const subscriptions = await Subscription.getAllForInstallation(installationId, githubHost);
     // Only show the page if the logged in user is an admin of this installation
     if (await isAdmin({
@@ -33,7 +37,7 @@ module.exports = async (req, res, next) => {
       return next(new Error('Unauthorized'));
     }
   } catch (err) {
-    console.log(`Unable to show subscription page. error=${err}, installation=${req.params.installationId}`);
+    console.log(`Unable to show subscription page. error=${err}, installation=${installationId}`);
     return next(new Error('Not Found'));
   }
 };

--- a/lib/frontend/get-github-subscriptions.js
+++ b/lib/frontend/get-github-subscriptions.js
@@ -7,13 +7,14 @@ module.exports = async (req, res, next) => {
 
   const { github, client, isAdmin } = res.locals;
 
-  const { installationId } = req.params;
+  const { installationId } = req.query;
   try {
     const { data: { login } } = await github.users.getAuthenticated();
     // get the installation to see if the user is an admin of it
     const { data: installation } = await client.apps.getInstallation({ installation_id: installationId });
-    // get all subscriptions from the database for this installation ID
-    const subscriptions = await Subscription.getAllForInstallation(installationId);
+    // get all subscriptions from the database for this installation ID and githubHost
+    const githubHost = new URL(installation.html_url).hostname;
+    const subscriptions = await Subscription.getAllForInstallation(installationId, githubHost);
     // Only show the page if the logged in user is an admin of this installation
     if (await isAdmin({
       org: installation.account.login,

--- a/lib/frontend/post-github-configuration.js
+++ b/lib/frontend/post-github-configuration.js
@@ -56,11 +56,19 @@ module.exports = async (req, res) => {
       }
     }
 
+    if (!userInstallation || !userInstallation.html_url) {
+      res.status(400);
+      res.json({
+        err: `html_url in Installation payload is empty. Installation=${req.body.installationId}.`,
+      });
+      return;
+    }
+
     const subscription = await Subscription.install({
       clientKey: getHashedKey(req.body.clientKey),
       installationId: req.body.installationId,
       host: req.session.jiraHost,
-      githubHost: (userInstallation && userInstallation.html_url && new URL(userInstallation.html_url).hostname),
+      githubHost: new URL(userInstallation.html_url).hostname,
     });
     const jiraInstallation = await Installation.getForHost(req.session.jiraHost);
     const action = ActionFromSubscription(subscription, jiraInstallation);

--- a/lib/frontend/post-github-configuration.js
+++ b/lib/frontend/post-github-configuration.js
@@ -60,7 +60,7 @@ module.exports = async (req, res) => {
       clientKey: getHashedKey(req.body.clientKey),
       installationId: req.body.installationId,
       host: req.session.jiraHost,
-      githubHost: new URL(userInstallation.html_url).hostname,
+      githubHost: (userInstallation && userInstallation.html_url && new URL(userInstallation.html_url).hostname),
     });
     const jiraInstallation = await Installation.getForHost(req.session.jiraHost);
     const action = ActionFromSubscription(subscription, jiraInstallation);

--- a/lib/frontend/post-github-configuration.js
+++ b/lib/frontend/post-github-configuration.js
@@ -60,6 +60,7 @@ module.exports = async (req, res) => {
       clientKey: getHashedKey(req.body.clientKey),
       installationId: req.body.installationId,
       host: req.session.jiraHost,
+      githubHost: new URL(userInstallation.html_url).hostname,
     });
     const jiraInstallation = await Installation.getForHost(req.session.jiraHost);
     const action = ActionFromSubscription(subscription, jiraInstallation);

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -82,8 +82,8 @@ module.exports = function middleware(callback) {
       context.log.error({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicitly ignored');
       return;
     }
-
-    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId);
+    const githubHost = new URL(context.payload.sender.html_url).hostname;
+    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId, githubHost);
     if (!subscriptions.length) {
       context.log.error({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
       return;

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -82,7 +82,7 @@ module.exports = function middleware(callback) {
       context.log.error({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicitly ignored');
       return;
     }
-    const githubHost = new URL(context.payload.sender.html_url).hostname;
+    const githubHost = (context.payload.sender && context.payload.sender.html_url && new URL(context.payload.sender.html_url).hostname);
     const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId, githubHost);
     if (!subscriptions.length) {
       context.log.error({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -82,7 +82,13 @@ module.exports = function middleware(callback) {
       context.log.error({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicitly ignored');
       return;
     }
-    const githubHost = (context.payload.sender && context.payload.sender.html_url && new URL(context.payload.sender.html_url).hostname);
+
+    if (!context.payload.sender || !context.payload.sender.html_url) {
+      context.log.error({ noop: 'no_html_url', installation_id: context.payload.installation.id }, 'html_url in Installation payload is empty.');
+      return;
+    }
+
+    const githubHost = new URL(context.payload.sender.html_url).hostname;
     const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId, githubHost);
     if (!subscriptions.length) {
       context.log.error({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -11,6 +11,7 @@ module.exports = class Subscription extends Sequelize.Model {
         syncStatus: DataTypes.ENUM('PENDING', 'COMPLETE', 'ACTIVE', 'FAILED'),
         syncWarning: DataTypes.STRING,
         jiraClientKey: DataTypes.STRING,
+        githubHost: DataTypes.STRING,
       },
       { sequelize },
     );
@@ -24,10 +25,11 @@ module.exports = class Subscription extends Sequelize.Model {
     });
   }
 
-  static async getAllForInstallation(installationId) {
+  static async getAllForInstallation(installationId, host) {
     return Subscription.findAll({
       where: {
         gitHubInstallationId: installationId,
+        githubHost: host,
       },
     });
   }
@@ -64,6 +66,7 @@ module.exports = class Subscription extends Sequelize.Model {
         gitHubInstallationId: payload.installationId,
         jiraHost: payload.host,
         jiraClientKey: payload.clientKey,
+        githubHost: payload.githubHost,
       },
     });
 

--- a/static/js/github-configuration.js
+++ b/static/js/github-configuration.js
@@ -15,6 +15,23 @@ $('.install-link').click(function (event) {
   })
 })
 
+$('.manage-link').click(function (event) {
+  event.preventDefault()
+  const appUrl = document.querySelector('meta[name=public-url]').getAttribute('content');
+  const installationId = $(event.target).data('installation-id');
+  const jiraHost = document.getElementById('jiraHost').value;
+  const child = window.open(`${appUrl}/github/subscriptions/?installationId=${encodeURIComponent(installationId)}&xdm_e=${encodeURIComponent(jiraHost)}`,'_self')
+
+  const interval = setInterval(function () {
+    if (child.closed) {
+      clearInterval(interval)
+
+      AP.navigator.reload()
+    }
+  }, 100)
+})
+
+
 $('.delete-link').click(function (event) {
   event.preventDefault()
 

--- a/test/fixtures/branch-basic.json
+++ b/test/fixtures/branch-basic.json
@@ -15,7 +15,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/branch-delete.json
+++ b/test/fixtures/branch-delete.json
@@ -15,7 +15,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/branch-invalid-ref_type.json
+++ b/test/fixtures/branch-invalid-ref_type.json
@@ -15,7 +15,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/branch-no-issues.json
+++ b/test/fixtures/branch-no-issues.json
@@ -15,7 +15,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/deployment-basic.json
+++ b/test/fixtures/deployment-basic.json
@@ -40,7 +40,8 @@
     },
     "sender": {
       "login": "TestUser[bot]",
-      "type": "Bot"
+      "type": "Bot",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/issue-basic.json
+++ b/test/fixtures/issue-basic.json
@@ -16,7 +16,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/issue-comment-basic.json
+++ b/test/fixtures/issue-comment-basic.json
@@ -18,7 +18,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/issue-null-body.json
+++ b/test/fixtures/issue-null-body.json
@@ -16,7 +16,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/pull-request-basic.json
+++ b/test/fixtures/pull-request-basic.json
@@ -39,7 +39,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/pull-request-null-repo.json
+++ b/test/fixtures/pull-request-null-repo.json
@@ -28,7 +28,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/pull-request-remove-keys.json
+++ b/test/fixtures/pull-request-remove-keys.json
@@ -44,7 +44,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/pull-request-test-changes-with-branch.json
+++ b/test/fixtures/pull-request-test-changes-with-branch.json
@@ -44,7 +44,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/pull-request-triggered-by-bot.json
+++ b/test/fixtures/pull-request-triggered-by-bot.json
@@ -39,7 +39,8 @@
         "updated_at": "test-pull-request-update-time"
       },
       "sender": {
-        "type": "Bot"
+        "type": "Bot",
+        "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
       },
       "installation": {
         "id": 1234
@@ -86,7 +87,8 @@
         "updated_at": "test-pull-request-update-time"
       },
       "sender": {
-        "type": "Bot"
+        "type": "Bot",
+        "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
       },
       "installation": {
         "id": 1234
@@ -133,7 +135,8 @@
         "updated_at": "test-pull-request-update-time"
       },
       "sender": {
-        "type": "Bot"
+        "type": "Bot",
+        "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
       },
       "installation": {
         "id": 1234

--- a/test/fixtures/push-basic.json
+++ b/test/fixtures/push-basic.json
@@ -27,7 +27,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/push-empty.json
+++ b/test/fixtures/push-empty.json
@@ -26,7 +26,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/push-mixed.json
+++ b/test/fixtures/push-mixed.json
@@ -48,7 +48,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/push-no-issues.json
+++ b/test/fixtures/push-no-issues.json
@@ -26,7 +26,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/fixtures/workflow-basic.json
+++ b/test/fixtures/workflow-basic.json
@@ -37,7 +37,8 @@
     },
     "sender": {
       "type": "User",
-      "login": "TestUser"
+      "login": "TestUser",
+      "html_url": "https://test.ghaekube.net/organizations/test-org/settings/installations/1"
     },
     "installation": {
       "id": 1234

--- a/test/setup/app.js
+++ b/test/setup/app.js
@@ -35,7 +35,7 @@ beforeEach(async () => {
       sharedSecret: process.env.ATLASSIAN_SECRET,
     });
 
-  td.when(models.Subscription.getAllForInstallation(1234))
+  td.when(models.Subscription.getAllForInstallation(1234, 'test.ghaekube.net'))
     .thenReturn([
       {
         jiraHost: process.env.ATLASSIAN_URL,

--- a/test/unit/frontend/github-configuration.test.js
+++ b/test/unit/frontend/github-configuration.test.js
@@ -39,6 +39,7 @@ const userInstallationsResponse = {
       },
       id: 1,
       target_type: 'Organization',
+      html_url: 'https://test.ghaekube.net/organizations/test-org/settings/installations/1',
     },
     {
       id: 3,
@@ -157,6 +158,7 @@ describe('Frontend', () => {
           installationId: '1',
           host: jiraHost,
           clientKey: getHashedKey(jiraClientKey),
+          githubHost: 'test.ghaekube.net',
         }));
       });
     });

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -20,7 +20,10 @@ describe('Probot event middleware', () => {
       });
       context = {
         payload: {
-          sender: { type: 'not bot' },
+          sender: {
+            type: 'not bot',
+            html_url: 'https://test.ghaekube.net/organizations/test-org/settings/installations/1',
+          },
           installation: { id: 1234 },
         },
         github: GitHubAPI(),

--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -57,12 +57,14 @@ describe('test installation model', () => {
       host: installation.jiraHost,
       installationId: '1234',
       clientKey: installation.clientKey,
+      githubHost: 'test-host',
     });
 
     await Subscription.install({
       host: installation.jiraHost,
       installationId: '2345',
       clientKey: installation.clientKey,
+      githubHost: 'test-host',
     });
   });
 

--- a/views/github-configuration.hbs
+++ b/views/github-configuration.hbs
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="ap-local-base-url" content="{{localBaseUrl}}">
+  <meta name="public-url" content="{{APP_URL}}">
   <title>{{title}}</title>
   <link rel="stylesheet" href="/public/primer/build.css" media="all" />
   <script src="/public/js/jquery.min.js"></script>
@@ -28,7 +29,7 @@
           <span class="text-bold text-gray-dark"><a href="{{html_url}}">{{ account.login }}</a></span>
           {{#if admin}}
             <button class="install-link btn btn-info float-right"  data-installation-id="{{ id }}" type="submit">Install</button>
-            <a href="/github/subscriptions/{{ id }}" class="float-right my-1 px-1">Manage</a>
+            <button class="manage-link btn btn-info float-right"  data-installation-id="{{ id }}" type="submit">Manage</button>
           {{else unless hasMemberPermission}}
             <a href="{{html_url}}/permissions/update" class="tooltipped tooltipped-w float-right" aria-label="Permissions update required to determine org membership." data-installation-id="{{ id }}">
               Update

--- a/views/github-configuration.hbs
+++ b/views/github-configuration.hbs
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="ap-local-base-url" content="{{localBaseUrl}}">
-  <meta name="public-url" content="{{APP_URL}}">
+  <meta name="public-url" content="{{appUrl}}">
   <title>{{title}}</title>
   <link rel="stylesheet" href="/public/primer/build.css" media="all" />
   <script src="/public/js/jquery.min.js"></script>


### PR DESCRIPTION
InstallationId is unique to org. Since we will be supporting multiple accounts/instances. InstallationId can be same for 2 different accounts.

Hence while saving `subscription` details to table need to save `githubHost` details as well
Also while retrieving `subscriptions` based on `installationId`, `githubHost` also needs to be passed.

This PR incorporates these changes.